### PR TITLE
feat(web): donation link exists or not

### DIFF
--- a/web/pages/user/[userId]/index.tsx
+++ b/web/pages/user/[userId]/index.tsx
@@ -205,19 +205,25 @@ function UserPage({
                                                         <ListIcon as={ChevronUpIcon} color="green.500" />
                                                     </span>
                                                 ) : null;
+                                            const SiteName =
+                                                safeUrl !== "" ? (
+                                                    <Link
+                                                        href={safeUrl}
+                                                        borderBottom={"1px"}
+                                                        borderColor={"blue.200"}
+                                                        isExternal={true}
+                                                    >
+                                                        {item.to}
+                                                    </Link>
+                                                ) : (
+                                                    `${item.to}`
+                                                );
                                             return (
                                                 <ListItem key={item.id} id={item.id}>
                                                     <Flex alignItems={"baseline"}>
                                                         <Box padding="2">
                                                             {Icon}
-                                                            <Link
-                                                                href={safeUrl}
-                                                                borderBottom={"1px"}
-                                                                borderColor={"blue.200"}
-                                                                isExternal={true}
-                                                            >
-                                                                {item.to}
-                                                            </Link>
+                                                            {SiteName}
                                                             {Amount}
                                                         </Box>
                                                         <Spacer />


### PR DESCRIPTION
If the donation destination URL is empty, `<Link>` component will be generated.
Now, if the URL is not included, the user page will be displayed in a separate tab.

<img width="1082" alt="Screen Shot 2021-05-01 at 16 51 04" src="https://user-images.githubusercontent.com/1996642/116775361-a3d27c00-aa9d-11eb-9e74-8c1dbe158ffc.png">

Suggested: Only text will be displayed when the text is empty.

*Sorry, I have not seen the actual screen because I could not reproduce the user page in my local environment...*